### PR TITLE
PaX support for builder

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:7.9-alpine
 
-RUN apk update && apk add --no-cache git
+RUN apk update && apk add --no-cache git paxctl
+
+RUN paxctl -cm /usr/local/bin/node
 
 RUN npm install -g pkg
 


### PR DESCRIPTION
This allows running dockerpkg containers with kernels that have memory protection from PaX enabled

Also see https://en.wikibooks.org/wiki/Grsecurity/Application-specific_Settings#Node.js :)

And thanks for the cool project, it's nice to have a small image =^_^=